### PR TITLE
Fix capitalisation of `swift`; nitpick what's part of a compiler 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If you'd like to learn more about how it works you can read about the philosophy
 
 #### Swift Package Manager
 
-The [Swift Package Manager](https://www.swift.org/package-manager) is a tool for automating the distribution of Swift code and is integrated into the swift compiler.
+The [Swift Package Manager](https://www.swift.org/package-manager) is a tool for automating the distribution of Swift code and is integrated into the Swift build system.
 
 Once you have your Swift package set up, adding Bodega as a dependency is as easy as adding it to the dependencies value of your `Package.swift`.
 


### PR DESCRIPTION
This had lowercase `s` swift in it, and also, while a pedantic distinction, I think saying SPM is part of the _compiler_ is incorrect; the [swift.org](https://www.swift.org/package-manager/) website calls it part of the _build system_, so I think that language is more appropriate.