### PR TITLE
Add modificationDate and accessDate to DiskStorage

### DIFF
--- a/Sources/Bodega/DiskStorage.swift
+++ b/Sources/Bodega/DiskStorage.swift
@@ -35,26 +35,6 @@ public actor DiskStorage {
     public func read(key: CacheKey, subdirectory: String? = nil) -> Data? {
         return try? Data(contentsOf: self.concatenatedPath(key: key.value, subdirectory: subdirectory))
     }
-    
-    /// Returns the modification date of the `CacheKey`, if it exists.
-    /// - Parameters:
-    ///   - key: A `CacheKey` for matching Data to a location on disk.
-    ///   - subdirectory: An optional subdirectory the caller can read from.
-    /// - Returns: The modification date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
-    public func modificationDate(key: CacheKey, subdirectory: String? = nil) -> Date? {
-        return try? self.concatenatedPath(key: key.value, subdirectory: subdirectory)
-            .resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
-    }
-    
-    /// Returns the last access date of the `CacheKey`, if it exists.
-    /// - Parameters:
-    ///   - key: A `CacheKey` for matching Data to a location on disk.
-    ///   - subdirectory: An optional subdirectory the caller can read from.
-    /// - Returns: The last access date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
-    public func accessDate(key: CacheKey, subdirectory: String? = nil) -> Date? {
-        return try? self.concatenatedPath(key: key.value, subdirectory: subdirectory)
-            .resourceValues(forKeys: [.contentAccessDateKey]).contentAccessDate
-    }
 
     /// Removes `Data` from disk with the associated `CacheKey`.
     /// - Parameters:
@@ -116,6 +96,36 @@ public actor DiskStorage {
     /// - Returns: The file/key count.
     public func keyCount(inSubdirectory subdirectory: String? = nil) -> Int {
         return self.allKeys(inSubdirectory: subdirectory).count
+    }
+
+    /// Returns the date of creation for the file represented by the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The last access date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
+    public func createdAt(key: CacheKey, subdirectory: String? = nil) -> Date? {
+        return try? self.concatenatedPath(key: key.value, subdirectory: subdirectory)
+            .resourceValues(forKeys: [.creationDateKey]).creationDate
+    }
+
+    /// Returns the last access date of the file behind the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The last access date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
+    public func lastAccessed(key: CacheKey, subdirectory: String? = nil) -> Date? {
+        return try? self.concatenatedPath(key: key.value, subdirectory: subdirectory)
+            .resourceValues(forKeys: [.contentAccessDateKey]).contentAccessDate
+    }
+
+    /// Returns the modification date for the file represented by the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The modification date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
+    public func lastModified(key: CacheKey, subdirectory: String? = nil) -> Date? {
+        return try? self.concatenatedPath(key: key.value, subdirectory: subdirectory)
+            .resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
     }
 
 }

--- a/Sources/Bodega/DiskStorage.swift
+++ b/Sources/Bodega/DiskStorage.swift
@@ -35,6 +35,26 @@ public actor DiskStorage {
     public func read(key: CacheKey, subdirectory: String? = nil) -> Data? {
         return try? Data(contentsOf: self.concatenatedPath(key: key.value, subdirectory: subdirectory))
     }
+    
+    /// Returns the modification date of the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The modification date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
+    public func modificationDate(key: CacheKey, subdirectory: String? = nil) -> Date? {
+        return try? self.concatenatedPath(key: key.value, subdirectory: subdirectory)
+            .resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+    }
+    
+    /// Returns the last access date of the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The last access date date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
+    public func accessDate(key: CacheKey, subdirectory: String? = nil) -> Date? {
+        return try? self.concatenatedPath(key: key.value, subdirectory: subdirectory)
+            .resourceValues(forKeys: [.contentAccessDateKey]).contentAccessDate
+    }
 
     /// Removes `Data` from disk with the associated `CacheKey`.
     /// - Parameters:

--- a/Sources/Bodega/DiskStorage.swift
+++ b/Sources/Bodega/DiskStorage.swift
@@ -50,7 +50,7 @@ public actor DiskStorage {
     /// - Parameters:
     ///   - key: A `CacheKey` for matching Data to a location on disk.
     ///   - subdirectory: An optional subdirectory the caller can read from.
-    /// - Returns: The last access date date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
+    /// - Returns: The last access date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
     public func accessDate(key: CacheKey, subdirectory: String? = nil) -> Date? {
         return try? self.concatenatedPath(key: key.value, subdirectory: subdirectory)
             .resourceValues(forKeys: [.contentAccessDateKey]).contentAccessDate

--- a/Sources/Bodega/ObjectStorage.swift
+++ b/Sources/Bodega/ObjectStorage.swift
@@ -33,24 +33,6 @@ public actor ObjectStorage {
 
         return try? JSONDecoder().decode(Object.self, from: data)
     }
-    
-    /// Returns the modification date of the `CacheKey`, if it exists.
-    /// - Parameters:
-    ///   - key: A `CacheKey` for matching Data to a location on disk.
-    ///   - subdirectory: An optional subdirectory the caller can read from.
-    /// - Returns: The modification date of the object on disk if it exists, nil if there is no object stored behind the `CacheKey`.
-    public func modificationDate(key: CacheKey, subdirectory: String? = nil) async -> Date? {
-        return await storage.modificationDate(key: key, subdirectory: subdirectory)
-    }
-    
-    /// Returns the last access date of the `CacheKey`, if it exists.
-    /// - Parameters:
-    ///   - key: A `CacheKey` for matching Data to a location on disk.
-    ///   - subdirectory: An optional subdirectory the caller can read from.
-    /// - Returns: The last access date of the object on disk if it exists, nil if there is no object stored behind the `CacheKey`.
-    public func accessDate(key: CacheKey, subdirectory: String? = nil) async -> Date? {
-        return await storage.accessDate(key: key, subdirectory: subdirectory)
-    }
 
     /// Removes an object from disk with the associated `CacheKey`.
     /// - Parameters:
@@ -78,6 +60,33 @@ public actor ObjectStorage {
     /// - Returns: The file/key count.
     public func keyCount(inSubdirectory subdirectory: String? = nil) async -> Int {
         return await storage.keyCount(inSubdirectory: subdirectory)
+    }
+
+    /// Returns the date of creation for the object represented by the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The last access date of the data on disk if it exists, nil if there is no data stored behind the `CacheKey`.
+    public func creationDate(forKey key: CacheKey, subdirectory: String? = nil) async -> Date? {
+        return await storage.createdAt(key: key, subdirectory: subdirectory)
+    }
+
+    /// Returns the last access date of the object behind the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The last access date of the object on disk if it exists, nil if there is no object stored behind the `CacheKey`.
+    public func lastAccessed(forKey key: CacheKey, subdirectory: String? = nil) async -> Date? {
+        return await storage.lastAccessed(key: key, subdirectory: subdirectory)
+    }
+
+    /// Returns the modification date for the object represented by the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The modification date of the object on disk if it exists, nil if there is no object stored behind the `CacheKey`.
+    public func lastModified(forKey key: CacheKey, subdirectory: String? = nil) async -> Date? {
+        return await storage.lastModified(key: key, subdirectory: subdirectory)
     }
 
 }

--- a/Sources/Bodega/ObjectStorage.swift
+++ b/Sources/Bodega/ObjectStorage.swift
@@ -33,6 +33,24 @@ public actor ObjectStorage {
 
         return try? JSONDecoder().decode(Object.self, from: data)
     }
+    
+    /// Returns the modification date of the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The modification date of the object on disk if it exists, nil if there is no object stored behind the `CacheKey`.
+    public func modificationDate(key: CacheKey, subdirectory: String? = nil) async -> Date? {
+        return await storage.modificationDate(key: key, subdirectory: subdirectory)
+    }
+    
+    /// Returns the last access date of the `CacheKey`, if it exists.
+    /// - Parameters:
+    ///   - key: A `CacheKey` for matching Data to a location on disk.
+    ///   - subdirectory: An optional subdirectory the caller can read from.
+    /// - Returns: The last access date of the object on disk if it exists, nil if there is no object stored behind the `CacheKey`.
+    public func accessDate(key: CacheKey, subdirectory: String? = nil) async -> Date? {
+        return await storage.accessDate(key: key, subdirectory: subdirectory)
+    }
 
     /// Removes an object from disk with the associated `CacheKey`.
     /// - Parameters:

--- a/Tests/BodegaTests/DiskStorageTests.swift
+++ b/Tests/BodegaTests/DiskStorageTests.swift
@@ -115,63 +115,63 @@ final class DiskStorageTests: XCTestCase {
     
     func testModificationDate() async throws {
         // Make sure the modificationDate is nil if the key hasn't been stored
-        var mod = await storage.modificationDate(key: Self.testCacheKey)
-        XCTAssertNil(mod)
+        var modificationDate = await storage.modificationDate(key: Self.testCacheKey)
+        XCTAssertNil(modificationDate)
         
         // Make sure the modification date is in the right range if it has been stored
-        var pre = Date()
+        var dateBefore = Date()
         try await storage.write(Self.testData, key: Self.testCacheKey)
-        var post = Date()
-        mod = await storage.modificationDate(key: Self.testCacheKey)
-        XCTAssertNotNil(mod)
-        XCTAssertLessThanOrEqual(pre, mod!)
-        XCTAssertLessThanOrEqual(mod!, post)
+        var dateAfter = Date()
+        modificationDate = await storage.modificationDate(key: Self.testCacheKey)
+        XCTAssertNotNil(modificationDate)
+        XCTAssertLessThanOrEqual(dateBefore, modificationDate!)
+        XCTAssertLessThanOrEqual(modificationDate!, dateAfter)
         
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         // Make sure the modification date is updated when the data is re-written
-        pre = Date()
+        dateBefore = Date()
         try await storage.write(Self.testData, key: Self.testCacheKey)
-        post = Date()
-        mod = await storage.modificationDate(key: Self.testCacheKey)
-        XCTAssertNotNil(mod)
-        XCTAssertLessThanOrEqual(pre, mod!)
-        XCTAssertLessThanOrEqual(mod!, post)
+        dateAfter = Date()
+        modificationDate = await storage.modificationDate(key: Self.testCacheKey)
+        XCTAssertNotNil(modificationDate)
+        XCTAssertLessThanOrEqual(dateBefore, modificationDate!)
+        XCTAssertLessThanOrEqual(modificationDate!, dateAfter)
     }
     
     func testAccessDate() async throws {
         // Make sure the accessDate is nil if the key hasn't been stored
-        var acc = await storage.accessDate(key: Self.testCacheKey)
-        XCTAssertNil(acc)
+        var accessDate = await storage.accessDate(key: Self.testCacheKey)
+        XCTAssertNil(accessDate)
         
         // Make sure the access date is in the right range if it has been stored
-        var pre = Date()
+        var dateBefore = Date()
         try await storage.write(Self.testData, key: Self.testCacheKey)
-        var post = Date()
-        acc = await storage.accessDate(key: Self.testCacheKey)
-        XCTAssertNotNil(acc)
-        XCTAssertLessThanOrEqual(pre, acc!)
-        XCTAssertLessThanOrEqual(acc!, post)
+        var dateAfter = Date()
+        accessDate = await storage.accessDate(key: Self.testCacheKey)
+        XCTAssertNotNil(accessDate)
+        XCTAssertLessThanOrEqual(dateBefore, accessDate!)
+        XCTAssertLessThanOrEqual(accessDate!, dateAfter)
         
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         // Make sure the access date is updated when the data is read
-        pre = Date()
+        dateBefore = Date()
         let data = await storage.read(key: Self.testCacheKey)
-        post = Date()
+        dateAfter = Date()
         XCTAssert(data == Self.testData)
-        acc = await storage.accessDate(key: Self.testCacheKey)
-        XCTAssertNotNil(acc)
-        XCTAssertLessThanOrEqual(pre, acc!)
+        accessDate = await storage.accessDate(key: Self.testCacheKey)
+        XCTAssertNotNil(accessDate)
+        XCTAssertLessThanOrEqual(dateBefore, accessDate!)
         // Note that there is a slight delay between reading the data and the access time,
         // so we need to allow for that.
-        XCTAssertLessThanOrEqual(acc!, post.addingTimeInterval(0.001))
+        XCTAssertLessThanOrEqual(accessDate!, dateAfter.addingTimeInterval(0.001))
         
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         // Make sure fetching the access date doesn't change the access date
-        let acc2 = await storage.accessDate(key: Self.testCacheKey)
-        XCTAssertEqual(acc, acc2)
+        let accessDate2 = await storage.accessDate(key: Self.testCacheKey)
+        XCTAssertEqual(accessDate, accessDate2)
     }
 
 }

--- a/Tests/BodegaTests/ObjectStorageTests.swift
+++ b/Tests/BodegaTests/ObjectStorageTests.swift
@@ -113,6 +113,67 @@ final class ObjectStorageTests: XCTestCase {
         XCTAssert(allKeys[3].value == "3")
         XCTAssert(allKeys.count == 10)
     }
+    
+    func testModificationDate() async throws {
+        // Make sure the modificationDate is nil if the key hasn't been stored
+        var modificationDate = await storage.modificationDate(key: Self.testCacheKey)
+        XCTAssertNil(modificationDate)
+        
+        // Make sure the modification date is in the right range if it has been stored
+        var dateBefore = Date()
+        try await storage.store(Self.testObject, forKey: Self.testCacheKey)
+        var dateAfter = Date()
+        modificationDate = await storage.modificationDate(key: Self.testCacheKey)
+        XCTAssertNotNil(modificationDate)
+        XCTAssertLessThanOrEqual(dateBefore, modificationDate!)
+        XCTAssertLessThanOrEqual(modificationDate!, dateAfter)
+        
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        // Make sure the modification date is updated when the data is re-written
+        dateBefore = Date()
+        try await storage.store(Self.testObject, forKey: Self.testCacheKey)
+        dateAfter = Date()
+        modificationDate = await storage.modificationDate(key: Self.testCacheKey)
+        XCTAssertNotNil(modificationDate)
+        XCTAssertLessThanOrEqual(dateBefore, modificationDate!)
+        XCTAssertLessThanOrEqual(modificationDate!, dateAfter)
+    }
+    
+    func testAccessDate() async throws {
+        // Make sure the accessDate is nil if the key hasn't been stored
+        var accessDate = await storage.accessDate(key: Self.testCacheKey)
+        XCTAssertNil(accessDate)
+        
+        // Make sure the access date is in the right range if it has been stored
+        var dateBefore = Date()
+        try await storage.store(Self.testObject, forKey: Self.testCacheKey)
+        var dateAfter = Date()
+        accessDate = await storage.accessDate(key: Self.testCacheKey)
+        XCTAssertNotNil(accessDate)
+        XCTAssertLessThanOrEqual(dateBefore, accessDate!)
+        XCTAssertLessThanOrEqual(accessDate!, dateAfter)
+        
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        // Make sure the access date is updated when the data is read
+        dateBefore = Date()
+        let object: CodableObject? = await storage.object(forKey: Self.testCacheKey)
+        dateAfter = Date()
+        XCTAssert(object == Self.testObject)
+        accessDate = await storage.accessDate(key: Self.testCacheKey)
+        XCTAssertNotNil(accessDate)
+        XCTAssertLessThanOrEqual(dateBefore, accessDate!)
+        // Note that there is a slight delay between reading the data and the access time,
+        // so we need to allow for that.
+        XCTAssertLessThanOrEqual(accessDate!, dateAfter.addingTimeInterval(0.001))
+        
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        // Make sure fetching the access date doesn't change the access date
+        let accessDate2 = await storage.accessDate(key: Self.testCacheKey)
+        XCTAssertEqual(accessDate, accessDate2)
+    }
 
 }
 


### PR DESCRIPTION
Add `modificationDate()` and `accessDate()` functions to DiskStorage to support cache maintenance.

The modification date is useful when deciding whether to re-fetch the cached value of a remote resource.

The access date is useful when clearing a cache of data that hasn't been used recently.

Unit tests are included.

Signed-off-by: Stuart A. Malone <samalone@llamagraphics.com>