### PR TITLE
Add bulk key existence checking

### DIFF
--- a/Sources/Bodega/DiskStorageEngine.swift
+++ b/Sources/Bodega/DiskStorageEngine.swift
@@ -31,7 +31,7 @@ public actor DiskStorageEngine: StorageEngine {
     ///   - data: The `Data` being stored to disk.
     ///   - key: A ``CacheKey`` for matching `Data` to a location on disk.
     public func write(_ data: Data, key: CacheKey) throws {
-        let fileURL = self.concatenatedPath(key: key.value)
+        let fileURL = self.concatenatedPath(key: key)
         let folderURL = fileURL.deletingLastPathComponent()
 
         if !Self.directoryExists(atURL: folderURL) {
@@ -56,7 +56,7 @@ public actor DiskStorageEngine: StorageEngine {
     ///   - key: A ``CacheKey`` for matching `Data` to a location on disk.
     /// - Returns: The `Data` stored on disk if it exists, nil if there is no `Data` stored for the `CacheKey`.
     public func read(key: CacheKey) -> Data? {
-        return try? Data(contentsOf: self.concatenatedPath(key: key.value))
+        return try? Data(contentsOf: self.concatenatedPath(key: key))
     }
 
     /// Reads `Data` from disk based on the associated array of ``CacheKey``s provided as a parameter
@@ -104,7 +104,7 @@ public actor DiskStorageEngine: StorageEngine {
     ///   - key: A ``CacheKey`` for matching `Data` to a location on disk.
     public func remove(key: CacheKey) throws {
         do {
-            try FileManager.default.removeItem(at: self.concatenatedPath(key: key.value))
+            try FileManager.default.removeItem(at: self.concatenatedPath(key: key))
         } catch CocoaError.fileNoSuchFile {
             // No-op, we treat deleting a non-existent file/folder as a successful removal rather than throwing
         } catch {
@@ -154,7 +154,7 @@ public actor DiskStorageEngine: StorageEngine {
     ///   - key: A ``CacheKey`` for matching `Data` to a location on disk.
     /// - Returns: The creation date of the `Data` on disk if it exists, nil if there is no `Data` stored for the `CacheKey`.
     public func createdAt(key: CacheKey) -> Date? {
-        return try? self.concatenatedPath(key: key.value)
+        return try? self.concatenatedPath(key: key)
             .resourceValues(forKeys: [.creationDateKey]).creationDate
     }
 
@@ -163,7 +163,7 @@ public actor DiskStorageEngine: StorageEngine {
     ///   - key: A ``CacheKey`` for matching `Data` to a location on disk.
     /// - Returns: The updatedAt date of the `Data` on disk if it exists, nil if there is no `Data` stored for the ``CacheKey``.
     public func updatedAt(key: CacheKey) -> Date? {
-        return try? self.concatenatedPath(key: key.value)
+        return try? self.concatenatedPath(key: key)
             .resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
     }
 
@@ -172,7 +172,7 @@ public actor DiskStorageEngine: StorageEngine {
     ///   - key: A ``CacheKey`` for matching `Data` to a location on disk.
     /// - Returns: The last access date of the `Data` on disk if it exists, nil if there is no `Data` stored for the ``CacheKey``.
     public func lastAccessed(key: CacheKey) -> Date? {
-        return try? self.concatenatedPath(key: key.value)
+        return try? self.concatenatedPath(key: key)
             .resourceValues(forKeys: [.contentAccessDateKey]).contentAccessDate
     }
 }
@@ -193,7 +193,7 @@ private extension DiskStorageEngine {
         return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
     }
 
-    func concatenatedPath(key: String) -> URL {
-        return self.directory.url.appendingPathComponent(key)
+    func concatenatedPath(key: CacheKey) -> URL {
+        return self.directory.url.appendingPathComponent(key.value)
     }
 }

--- a/Sources/Bodega/DiskStorageEngine.swift
+++ b/Sources/Bodega/DiskStorageEngine.swift
@@ -127,7 +127,8 @@ public actor DiskStorageEngine: StorageEngine {
     /// - Parameter key: The key to for existence.
     /// - Returns: If the key exists the function returns true, false if it does not.
     public func keyExists(_ key: CacheKey) -> Bool {
-        self.allKeys().contains(key)
+        let fileURL = self.concatenatedPath(key: key)
+        return Self.fileExists(atURL: fileURL)
     }
 
     /// Iterates through a directory to find the total number of `Data` items.
@@ -191,6 +192,13 @@ private extension DiskStorageEngine {
         var isDirectory: ObjCBool = true
 
         return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+    }
+    
+    static func fileExists(atURL url: URL) -> Bool {
+        var isDirectory: ObjCBool = true
+
+        let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        return exists == true && isDirectory.boolValue == false
     }
 
     func concatenatedPath(key: CacheKey) -> URL {

--- a/Sources/Bodega/DiskStorageEngine.swift
+++ b/Sources/Bodega/DiskStorageEngine.swift
@@ -124,6 +124,8 @@ public actor DiskStorageEngine: StorageEngine {
     }
 
     /// Checks whether a value with a key is persisted.
+    ///
+    /// This implementation provides `O(1)` checking for the key's existence.
     /// - Parameter key: The key to check for existence.
     /// - Returns: If the key exists the function returns true, false if it does not.
     public func keyExists(_ key: CacheKey) -> Bool {

--- a/Sources/Bodega/DiskStorageEngine.swift
+++ b/Sources/Bodega/DiskStorageEngine.swift
@@ -124,7 +124,7 @@ public actor DiskStorageEngine: StorageEngine {
     }
 
     /// Checks whether a value with a key is persisted.
-    /// - Parameter key: The key to for existence.
+    /// - Parameter key: The key to check for existence.
     /// - Returns: If the key exists the function returns true, false if it does not.
     public func keyExists(_ key: CacheKey) -> Bool {
         let fileURL = self.concatenatedPath(key: key)

--- a/Sources/Bodega/SQLiteStorageEngine.swift
+++ b/Sources/Bodega/SQLiteStorageEngine.swift
@@ -228,6 +228,24 @@ public actor SQLiteStorageEngine: StorageEngine {
             return false
         }
     }
+    
+    /// Filters the provided keys to return only the ones that exist in the engine
+    /// - Parameter keys: The list of keys to check for existence.
+    /// - Returns: An array of keys that exist. This value is always a subset of the `keys` passed in.
+    public func keysExist(_ keys: [CacheKey]) async -> [CacheKey] {
+        do {
+            let rawKeys = keys.map(\.rawValue)
+            
+            let query = Self.storageTable
+                .select(Self.expressions.keyRow)
+                .filter(rawKeys.contains(Self.expressions.keyRow))
+            
+            return try self.connection.prepare(query)
+                .map({ CacheKey(verbatim: $0[Self.expressions.keyRow]) })
+        } catch {
+            return []
+        }
+    }
 
     /// Iterates through the database to find the total number of `Data` items.
     /// - Returns: The file/key count.

--- a/Sources/Bodega/StorageEngine.swift
+++ b/Sources/Bodega/StorageEngine.swift
@@ -88,13 +88,6 @@ extension StorageEngine {
         return await self.readDataAndKeys(keys: allKeys)
     }
     
-    /// Checks whether a value with a key is persisted.
-    /// - Parameter key: The key to check for existence.
-    /// - Returns: If the key exists the function returns true, false if it does not.
-    public func keyExists(_ key: CacheKey) async -> Bool {
-        return await self.allKeys().contains(key)
-    }
-    
     /// Filters the provided keys to return only the ones that exist in the engine
     /// - Parameter keys: The list of keys to check for existence.
     /// - Returns: An array of keys that exist. This value is always a subset of the `keys` passed in.

--- a/Sources/Bodega/StorageEngine.swift
+++ b/Sources/Bodega/StorageEngine.swift
@@ -29,6 +29,7 @@ public protocol StorageEngine: Actor {
     func removeAllData() async throws
 
     func keyExists(_ key: CacheKey) async -> Bool
+    func keysExist(_ keys: [CacheKey]) async -> [CacheKey]
     func keyCount() async -> Int
     func allKeys() async -> [CacheKey]
 
@@ -92,6 +93,15 @@ extension StorageEngine {
     /// - Returns: If the key exists the function returns true, false if it does not.
     public func keyExists(_ key: CacheKey) async -> Bool {
         return await self.allKeys().contains(key)
+    }
+    
+    /// Filters the provided keys to return only the ones that exist in the engine
+    /// - Parameter keys: The list of keys to check for existence.
+    /// - Returns: An array of keys that exist. This value is always a subset of the `keys` passed in.
+    public func keysExist(_ keys: [CacheKey]) async -> [CacheKey] {
+        let allKeys = await self.allKeys()
+        let keySet = Set(allKeys)
+        return keys.filter { keySet.contains($0) }
     }
     
     /// Read the number of keys located in the ``StorageEngine``.

--- a/Sources/Bodega/StorageEngine.swift
+++ b/Sources/Bodega/StorageEngine.swift
@@ -86,4 +86,17 @@ extension StorageEngine {
         let allKeys = await self.allKeys()
         return await self.readDataAndKeys(keys: allKeys)
     }
+    
+    /// Checks whether a value with a key is persisted.
+    /// - Parameter key: The key to check for existence.
+    /// - Returns: If the key exists the function returns true, false if it does not.
+    public func keyExists(_ key: CacheKey) async -> Bool {
+        return await self.allKeys().contains(key)
+    }
+    
+    /// Read the number of keys located in the ``StorageEngine``.
+    /// - Returns: The number of keys located in the ``StorageEngine``
+    public func keyCount() async -> Int {
+        return await self.allKeys().count
+    }
 }

--- a/Tests/BodegaTests/DiskStorageEngineTests.swift
+++ b/Tests/BodegaTests/DiskStorageEngineTests.swift
@@ -217,6 +217,16 @@ final class DiskStorageEngineTests: XCTestCase {
         let cacheKeyExistsAfterRemovingData = await storage.keyExists(Self.testCacheKey)
         XCTAssertFalse(cacheKeyExistsAfterRemovingData)
     }
+    
+    func testKeysExist() async throws {
+        let allKeys = Self.storedKeysAndData.map(\.key) + [Self.testCacheKey]
+        let noKeysExistBeforeAddingData = await storage.keysExist(allKeys)
+        XCTAssertTrue(noKeysExistBeforeAddingData.isEmpty)
+        
+        try await storage.write(Self.testData, key: Self.testCacheKey)
+        let someKeysExist = await storage.keysExist(allKeys)
+        XCTAssertEqual(someKeysExist, [Self.testCacheKey])
+    }
 
     func testAllKeys() async throws {
         try await self.writeItemsToDisk(count: 10)

--- a/Tests/BodegaTests/SQLiteStorageEngineTests.swift
+++ b/Tests/BodegaTests/SQLiteStorageEngineTests.swift
@@ -216,6 +216,16 @@ final class SQLiteStorageEngineTests: XCTestCase {
         let cacheKeyExistsAfterRemovingData = await storage.keyExists(Self.testCacheKey)
         XCTAssertFalse(cacheKeyExistsAfterRemovingData)
     }
+    
+    func testKeysExist() async throws {
+        let allKeys = Self.storedKeysAndData.map(\.key) + [Self.testCacheKey]
+        let noKeysExistBeforeAddingData = await storage.keysExist(allKeys)
+        XCTAssertTrue(noKeysExistBeforeAddingData.isEmpty)
+        
+        try await storage.write(Self.testData, key: Self.testCacheKey)
+        let someKeysExist = await storage.keysExist(allKeys)
+        XCTAssertEqual(someKeysExist, [Self.testCacheKey])
+    }
 
     func testAllKeys() async throws {
         try await self.writeItemsToDatabase(count: 10)


### PR DESCRIPTION
When dealing with importing large amounts of data, it's helpful to be able to preemptively check for the existence of multiple keys before beginning importation.

This adds a single method to `StorageEngine`: `func keysExist(_ keys: [CacheKey]) async -> [CacheKey]`.

A default implementation does the sensible thing (retrieve `allKeys()` and then filter the parameter based on that), but `SQLiteStorageEngine` overrides it for storage-specific implementation details, to avoid loading every single key into memory.

This patch also contains other minor related improvements (documentation, performance improvements, etc).