### PR TITLE
Fix readDataAndKeys

### DIFF
--- a/Sources/Bodega/DiskStorageEngine.swift
+++ b/Sources/Bodega/DiskStorageEngine.swift
@@ -72,10 +72,15 @@ public actor DiskStorageEngine: StorageEngine {
     /// - Returns: An array of `[(CacheKey, Data)]` read from disk if the ``CacheKey``s exist,
     /// and an empty array if there are no `Data` items matching the `keys` passed in.
     public func readDataAndKeys(keys: [CacheKey]) async -> [(key: CacheKey, data: Data)] {
-        return zip(
-            keys,
-            await self.read(keys: keys)
-        ).map { ($0, $1) }
+        var dataAndKeys: [(key: CacheKey, data: Data)] = []
+
+        for key in keys {
+            if let data = self.read(key: key) {
+                dataAndKeys.append((key, data))
+            }
+        }
+
+        return dataAndKeys
     }
 
     /// Reads all the `[Data]` located in the `directory`.

--- a/Sources/Bodega/ObjectStorage.swift
+++ b/Sources/Bodega/ObjectStorage.swift
@@ -84,10 +84,15 @@ public actor ObjectStorage<Object: Codable> {
     /// - Returns: An array of `[(CacheKey, Object)]` read if it exists,
     /// and an empty array if there are no `Objects`s matching the `keys` passed in.
     public func objectsAndKeys(keys: [CacheKey]) async -> [(key: CacheKey, object: Object)] {
-        return zip(
-            keys,
-            await self.objects(forKeys: keys)
-        ).map { ($0, $1) }
+        var objectsAndKeys: [(key: CacheKey, object: Object)] = []
+
+        for key in keys {
+            if let object = await self.object(forKey: key) {
+                objectsAndKeys.append((key, object))
+            }
+        }
+
+        return objectsAndKeys
     }
 
     /// Reads all `[Object]` objects.

--- a/Tests/BodegaTests/DiskStorageEngineTests.swift
+++ b/Tests/BodegaTests/DiskStorageEngineTests.swift
@@ -84,6 +84,19 @@ final class DiskStorageEngineTests: XCTestCase {
             "Value 9"
         ])
     }
+    
+    func testReadingDataAndNonExistentKeys() async throws {
+        try await self.writeItemsToDisk(count: 5)
+        let allDataAndKeys = await storage.readAllDataAndKeys()
+            .sorted(by: { $0.key.value > $1.key.value })
+        
+        let goodAndBadKeys = (0 ..< 10).reversed().map({ CacheKey(verbatim: "\($0)") })
+        let validDataAndKeys = await storage.readDataAndKeys(keys: goodAndBadKeys)
+            .sorted(by: { $0.key.value > $1.key.value })
+        
+        XCTAssertEqual(allDataAndKeys.map(\.key), validDataAndKeys.map(\.key))
+        XCTAssertEqual(allDataAndKeys.map(\.data), validDataAndKeys.map(\.data))
+    }
 
     func testReadingAllDataSucceeds() async throws {
         try await self.writeItemsToDisk(count: 10)

--- a/Tests/BodegaTests/ObjectStorageTests.swift
+++ b/Tests/BodegaTests/ObjectStorageTests.swift
@@ -153,6 +153,19 @@ class ObjectStorageTests: XCTestCase {
         ])
     }
 
+    func testReadingObjectsAndNonExistentKeys() async throws {
+        try await self.writeObjectsToDisk(count: 5)
+        let allDataAndKeys = await storage.allObjectsAndKeys()
+            .sorted(by: { $0.key.value > $1.key.value })
+        
+        let goodAndBadKeys = (0 ..< 10).reversed().map({ CacheKey(verbatim: "\($0)") })
+        let validObjectsAndKeys = await storage.objectsAndKeys(keys: goodAndBadKeys)
+            .sorted(by: { $0.key.value > $1.key.value })
+        
+        XCTAssertEqual(allDataAndKeys.map(\.key), validObjectsAndKeys.map(\.key))
+        XCTAssertEqual(allDataAndKeys.map(\.object), validObjectsAndKeys.map(\.object))
+    }
+    
     func testReadingAllObjectsSucceeds() async throws {
         try await self.writeObjectsToDisk(count: 10)
 

--- a/Tests/BodegaTests/SQLiteStorageEngineTests.swift
+++ b/Tests/BodegaTests/SQLiteStorageEngineTests.swift
@@ -84,6 +84,19 @@ final class SQLiteStorageEngineTests: XCTestCase {
             "Value 9"
         ])
     }
+    
+    func testReadingDataAndNonExistentKeys() async throws {
+        try await self.writeItemsToDatabase(count: 5)
+        let allDataAndKeys = await storage.readAllDataAndKeys()
+            .sorted(by: { $0.key.value > $1.key.value })
+        
+        let goodAndBadKeys = (0 ..< 10).reversed().map({ CacheKey(verbatim: "\($0)") })
+        let validDataAndKeys = await storage.readDataAndKeys(keys: goodAndBadKeys)
+            .sorted(by: { $0.key.value > $1.key.value })
+        
+        XCTAssertEqual(allDataAndKeys.map(\.key), validDataAndKeys.map(\.key))
+        XCTAssertEqual(allDataAndKeys.map(\.data), validDataAndKeys.map(\.data))
+    }
 
     func testReadingAllDataSucceeds() async throws {
         try await self.writeItemsToDatabase(count: 10)


### PR DESCRIPTION
A bug exists in `readDataAndKeys` (#24) where requesting non-existent keys will cause subsequent keys to be associated with the wrong data.

This fixes that.