### PR TITLE
Vacuum sqlite database after removing all data

### DIFF
--- a/Sources/Bodega/SQLiteStorageEngine.swift
+++ b/Sources/Bodega/SQLiteStorageEngine.swift
@@ -211,6 +211,7 @@ public actor SQLiteStorageEngine: StorageEngine {
     /// Removes all the `Data` items from the database.
     public func removeAllData() throws {
         try self.connection.run(Self.storageTable.delete())
+        let _ = try? self.connection.vacuum()
     }
 
     /// Checks whether a value with a key is persisted.

--- a/Tests/BodegaTests/SQLiteStorageEngineTests.swift
+++ b/Tests/BodegaTests/SQLiteStorageEngineTests.swift
@@ -195,6 +195,25 @@ final class SQLiteStorageEngineTests: XCTestCase {
         XCTAssertEqual(updatedKeyCount, 0)
     }
 
+    func testVacuumAfterRemoveAllData() async throws {
+        let directory: FileManager.Directory = .temporary(appendingPath: "VacuumTests")
+        let otherStorage = SQLiteStorageEngine(directory: directory, databaseFilename: "data")!
+
+        for i in 0 ..< 100 {
+            // This encoding could fail in some use cases but we're going to use very simple strings for testing
+            try await otherStorage.write("Value \(i)".data(using: .utf8)!, key: CacheKey(verbatim: "\(i)"))
+        }
+
+        let filledDatabaseSize: Int = try directory.url.appendingPathComponent("data").appendingPathExtension("sqlite3").resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+
+        try await otherStorage.removeAllData()
+
+        let emptyDatabaseSize: Int = try directory.url.appendingPathComponent("data").appendingPathExtension("sqlite3").resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+
+        // check that the sqlite3 file decreased in size after calling removeAllData, meaning that vacuum-ing the database works
+        XCTAssertLessThan(emptyDatabaseSize, filledDatabaseSize)
+    }
+
     func testRemovingNonExistentObjectDoesNotError() async throws {
         try await storage.write(Self.testData, key: Self.testCacheKey)
         try await storage.remove(key: CacheKey(verbatim: "alternative-test-key"))


### PR DESCRIPTION
Bodega now calls `vacuum` on the SQLite database after removing all data. While vacuuming after deleting all data is useful, I don't think it's absolutely necessary. That's why I decided not to throw any errors from vacuuming. I also added a test to ensure this actually works.