### PR TITLE
Resolve ambiguous reference to Expression in iOS 18 SDK.

### DIFF
--- a/Sources/Bodega/SQLiteStorageEngine.swift
+++ b/Sources/Bodega/SQLiteStorageEngine.swift
@@ -326,20 +326,20 @@ private extension SQLiteStorageEngine {
 }
 
 private extension SQLiteStorageEngine.Expressions {
-    var keyRow: Expression<String> {
-        Expression<String>("key")
+    var keyRow: SQLite.Expression<String> {
+        SQLite.Expression<String>("key")
     }
 
-    var dataRow: Expression<Data> {
-        Expression<Data>("value")
+    var dataRow: SQLite.Expression<Data> {
+        SQLite.Expression<Data>("value")
     }
 
-    var createdAtRow: Expression<Date> {
-        Expression<Date>("createdAt")
+    var createdAtRow: SQLite.Expression<Date> {
+        SQLite.Expression<Date>("createdAt")
     }
 
-    var updatedAtRow: Expression<Date> {
-        Expression<Date>("updatedAt")
+    var updatedAtRow: SQLite.Expression<Date> {
+        SQLite.Expression<Date>("updatedAt")
     }
 }
 


### PR DESCRIPTION
The Foundation module in the iOS 18 SDK contains a new Expression type that conflicts with the Expression type in SQLite. Add an explicit prefix to resolve the ambiguity.