### PR TITLE
Skip storage writes for empty arrays

### DIFF
--- a/Sources/Bodega/DiskStorageEngine.swift
+++ b/Sources/Bodega/DiskStorageEngine.swift
@@ -46,6 +46,7 @@ public actor DiskStorageEngine: StorageEngine {
     ///   - dataAndKeys: An array of the `[(CacheKey, Data)]` to store
     ///   multiple `Data` items with their associated keys at once.
     public func write(_ dataAndKeys: [(key: CacheKey, data: Data)]) throws {
+        guard !dataAndKeys.isEmpty else { return }
         for dataAndKey in dataAndKeys {
             try self.write(dataAndKey.data, key: dataAndKey.key)
         }

--- a/Sources/Bodega/ObjectStorage.swift
+++ b/Sources/Bodega/ObjectStorage.swift
@@ -42,6 +42,7 @@ public actor ObjectStorage<Object: Codable> {
     ///   - objectsAndKeys: An array of `[(CacheKey, Object)]` to store
     ///   multiple objects with their associated keys at once.
     public func store(_ objectsAndKeys: [(key: CacheKey, object: Object)]) async throws {
+        guard !objectsAndKeys.isEmpty else { return }
         let dataAndKeys = try objectsAndKeys.map({ try ($0.key, self.encoder.encode($0.object)) })
 
         try await storage.write(dataAndKeys)
@@ -127,9 +128,8 @@ public actor ObjectStorage<Object: Codable> {
     /// - Parameters:
     ///   - keys: A `[CacheKey]` for matching multiple `Object`s.
     public func removeObject(forKeys keys: [CacheKey]) async throws {
-        for key in keys {
-            try await storage.remove(key: key)
-        }
+        guard !keys.isEmpty else { return }
+        try await storage.remove(keys: keys)
     }
 
     /// Removes all of the `Object`s.

--- a/Sources/Bodega/StorageEngine.swift
+++ b/Sources/Bodega/StorageEngine.swift
@@ -62,6 +62,7 @@ extension StorageEngine {
     /// - Parameters:
     ///   - keys: A `[CacheKey]` for matching multiple `Data` items.
     public func remove(keys: [CacheKey]) async throws {
+        guard !keys.isEmpty else { return }
         for key in keys {
             try await self.remove(key: key)
         }

--- a/Tests/BodegaTests/ObjectStorageTests.swift
+++ b/Tests/BodegaTests/ObjectStorageTests.swift
@@ -111,6 +111,13 @@ class ObjectStorageTests: XCTestCase {
         XCTAssertEqual(Self.storedKeysAndObjects.map(\.object), readKeysAndObjects.map(\.object))
     }
 
+    func testWritingEmptyObjectsAndKeys() async throws {
+        try await storage.store([] as [(key: CacheKey, object: CodableObject)])
+
+        let objectCount = await storage.keyCount()
+        XCTAssertEqual(objectCount, 0)
+    }
+
     func testReadingObjectSucceeds() async throws {
         // Read one object
         try await storage.store(Self.testObject, forKey: Self.testCacheKey)
@@ -249,6 +256,14 @@ class ObjectStorageTests: XCTestCase {
         XCTAssertEqual(allData[0].key, storedKeysAndData[3].key)
         XCTAssertEqual(allData[0].object, storedKeysAndData[3].object)
 
+    }
+
+    func testRemovingEmptyKeysDoesNothing() async throws {
+        try await storage.store(Self.storedKeysAndObjects)
+        try await storage.removeObject(forKeys: [] as [CacheKey])
+
+        let objectCount = await storage.keyCount()
+        XCTAssertEqual(objectCount, Self.storedKeysAndObjects.count)
     }
 
     func testInvalidRemoveErrors() async throws {


### PR DESCRIPTION
## Summary
- Avoid actor hops by returning early when inserts, updates, or removals contain no items
- Extend tests to confirm storing or removing empty collections performs no work

## Testing
- `swift test` *(fails: HTTP 403 cloning swift-crypto)*

------
https://chatgpt.com/codex/tasks/task_e_68a14c5fca34832e99356884572106c6