### PR TITLE
Add watchOS availability to FileManager.Directory guards

### DIFF
--- a/Sources/Bodega/FileManager.Directory.swift
+++ b/Sources/Bodega/FileManager.Directory.swift
@@ -28,7 +28,7 @@ public extension FileManager.Directory {
     /// - Parameter pathComponent: A path to append to the platform's documents directory.
     static func documents(appendingPath pathComponent: String) -> Self {
         let url: URL
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *) {
             url = URL.documentsDirectory.appending(path: pathComponent)
         } else {
             url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(pathComponent)
@@ -41,7 +41,7 @@ public extension FileManager.Directory {
     /// - Parameter pathComponent: A path to append to the platform's caches directory.
     static func caches(appendingPath pathComponent: String) -> Self {
         let url: URL
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *) {
             url = URL.cachesDirectory.appending(path: pathComponent)
         } else {
             url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(pathComponent)
@@ -54,7 +54,7 @@ public extension FileManager.Directory {
     /// - Parameter pathComponent: A path to append to the platform's temporary directory.
     static func temporary(appendingPath pathComponent: String) -> Self {
         let url: URL
-        if #available(iOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *) {
             url = URL.temporaryDirectory.appending(path: pathComponent)
         } else {
             url = FileManager.default.temporaryDirectory.appendingPathComponent(pathComponent)


### PR DESCRIPTION
`documents`/`caches`/`temporary` gate the modern URL.documentsDirectory etc. behind `if #available(iOS 16.0, macOS 13.0, *)`, omitting watchOS and tvOS. When the package is built with a watchOS deployment floor below 9.0 (Bodega declares no watchOS platform, so the floor is toolchain-dependent), the `*` lets watchOS-9.0-only API through unguarded and compilation fails with "'documentsDirectory' is only available in watchOS 9.0 or newer".

Add `watchOS 9.0, tvOS 16.0` to the three guards so the existing else-branch fallback (FileManager.default.urls(...), available since watchOS 2) is used on older floors. Verified: builds clean for watchOS Simulator on Xcode 26.6.